### PR TITLE
Feature: split stdout=>file_path, stderr=>msgs

### DIFF
--- a/ngatorA.sh
+++ b/ngatorA.sh
@@ -24,17 +24,42 @@ shift
 # ---------------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------------
-# stdout path
+
+# create temporary file
+stdout=$(mktemp)
+stderr=$(mktemp)
+
+# ---------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------
+# direct file descriptor ouput to temp files
 
 # stream=$(/mnt/c/Users/noahm/documents/dev_sandbox/ngator/ngatorB "$cwd" "$@")
-stream=$($PROGM_DIR/ngatorB "$cwd" "$@")
+# stream=$($PROGM_DIR/ngatorB "$cwd" "$@")
+
+"$PROGM_DIR/ngatorB" "$cwd" "$@" 1>"$stdout" 2>"$stderr"
+
 # ---------------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------------
 # exitcode, shellcode request
 
+# extract the exit code of the most recently executed command
 request_channel=$?
 # ---------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------
+# capture out and err data
+
+path=$(<"$stdout")
+out_s=$(<"$stderr")
+out_a=($out_s)
+
+rm "$stdout" "$stderr"
+
+# ---------------------------------------------------------------------------------
+
+echo "${out_a[0]}"
 
 # ---------------------------------------------------------------------------------
 # parse request
@@ -42,15 +67,15 @@ request_channel=$?
 case "$request_channel" in
   0)
     echo "do nothing"
-    echo"$stream"
+    echo"$path"
     ;;
   1|2|3)
     # add, delte, or list message
-    echo "$stream"
+    echo "$path"
     ;;
   4)
     # echo "goto"
-    cd "$stream"
+    cd "$path"
     ;;
   *)
     echo "NA"

--- a/ngatorB
+++ b/ngatorB
@@ -104,6 +104,24 @@ def goto_path(alias):
         else:
             print(f"No path found for alias:: {alias}")
 
+def get_all_alias():
+    with sqlite3.connect(database_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT alias FROM paths"
+        )
+        all_alias = cursor.fetchall()
+        # remove tuples
+        flattened = []
+        for row in all_alias:
+            flattened.append(row[0])
+
+        # prep data as a string
+        s_all_alias = ' '.join(flattened)
+
+        # send data to stderr channel
+        print(s_all_alias, file=sys.stderr)
+
 def to_stdout(path):
     # send the path to stdout
     print(path)
@@ -177,5 +195,9 @@ out = action(arg_flag)
 to_stdout(out)
 if broadcast == Signal.NONE:
     print(sys.argv)
+
+# sent alias through err
+get_all_alias()
+
 # send request through exit code to parent shell code
 sys.exit(broadcast.value)

--- a/setup.sh
+++ b/setup.sh
@@ -51,6 +51,7 @@ if [ "$rc" != "NA" ]; then
 
 echo "SHELL CODE WRAPPER >> .$shell_name.rc"
 
+# read from the config file to get the PROGM_DIR
 cat << EOF >> "$rc"
 # ----------------------------------------------------------
 # ngator utility parent shell access/startup


### PR DESCRIPTION
Print statements keep breaking the goto function from random prints muddying up the stdout stream output that should only contain the path

stdout: <path>
stderror: console feedback/printing
exitcode: ngatorB request

#15 

# There are a few concerns with the current implementation:

### create temporary file
stdout=$(mktemp)
stderr=$(mktemp)

"$PROGM_DIR/ngatorB" "$cwd" "$@" 1>"$stdout" 2>"$stderr"

### extract the exit code of the most recently executed command
request_channel=$?

### capture out and err data
path=$(<"$stdout")
out_s=$(<"$stderr")
out_a=($out_s)

rm "$stdout" "$stderr"

echo "${out_a[0]}"

# Concern
This creates 2 new files on disk, reads from them and then writes back to them. 
- I don't like the idea of writing/reading from disk every time the command runs

# Possible solutions
### 1. named pip but only works on linux file system
out_fifo=/tmp/out.$$
err_fifo=/tmp/err.$$
mkfifo "$out_fifo" "$err_fifo"

cat <"$out_fifo" > out.txt &
cat <"$err_fifo" > err.txt &

"$PWD/fdB.py" >"$out_fifo" 2>"$err_fifo"

wait  
stdout=$(<out.txt)
stderr=$(<err.txt)

rm "$out_fifo" "$err_fifo" out.txt err.txt

### 3. run the command twice
stdout=$("$PWD/fdB.py" 2>/dev/null)
stderr=$("$PWD/fdB.py" >/dev/null)
exitcode=$?


### 4. merge the stdout and error file descriptors and then parse the output after
result=$("$PWD/fdB.py" 2>&1)
exitcode=$?
echo "$result"

# Overview
I am looking into alternative solutions