### PR TITLE
fix(shell_execution.sh): rename path variable

### DIFF
--- a/shell_execution.sh
+++ b/shell_execution.sh
@@ -54,12 +54,12 @@ request_channel=$?
 # ---------------------------------------------------------------------------------
 # capture out and err data
 
-path=$(<"$stdout")
+target_path=$(<"$stdout")
 out_s=$(<"$stderr")
 out_a=($out_s)
 
 rm "$stdout" "$stderr"
-# echo $path
+# echo $target_path
 
 # ---------------------------------------------------------------------------------
 
@@ -77,15 +77,15 @@ case "$request_channel" in
     # echo "do nothing"
 
     # argparse prints to stdout for command mismatch
-    echo "$path"
+    echo "$target_path"
     ;;
   1|2|3|5|6)
     # subcommand feedback message
-    echo "$path"
+    echo "$target_path"
     ;;
   4)
     # echo "goto"
-    cd "$path"
+    cd "$target_path"
     ;;
   *)
     echo "shell_execution.sh(~89):: -m command not recognized"


### PR DESCRIPTION
# Mac support (rename path variable)

- fixes error to sustain mac support
- this line causes an error: path=$(<"$stdout")
- path is a special variable name in zsh.
- in zsh path is a special array that directly maps to PATH
- in bash this is not the case so the error only occured on mac
- (bash) path=foo   # harmless variable
- (zsh) path=foo   # modifies PATH
- path=$(...) in zsh overwrites PATH
- PATH="<contents of stdout>"
- overwrites your PATH with whatever your Python script printed

- That’s why immediately after:
- zsh: command not found: ls
- zsh: command not found: rm
- PATH is gone.

Fixes: #30